### PR TITLE
Add AdditionalInstrumentationDetail

### DIFF
--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiExceptionsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiExceptionsInstrumentation.cs
@@ -27,9 +27,9 @@ namespace Corvus.Monitoring.ApplicationInsights
         }
 
         /// <inheritdoc />
-        public void ReportException(Exception x)
+        public void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail)
         {
-            this.telemetryClient.TrackException(x);
+            this.telemetryClient.TrackException(x, additionalDetail?.Properties, additionalDetail?.Metrics);
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Monitoring.ApplicationInsights
 {
+    using System.Collections.Generic;
     using Corvus.Monitoring.Instrumentation;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -28,9 +29,26 @@ namespace Corvus.Monitoring.ApplicationInsights
         }
 
         /// <inheritdoc />
-        public IOperationInstance StartOperation(string name)
+        public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail additionalDetail)
         {
-            return new Operation(this.telemetryClient.StartOperation<RequestTelemetry>(name));
+            IOperationHolder<RequestTelemetry> operationHolder = this.telemetryClient.StartOperation<RequestTelemetry>(name);
+            if (additionalDetail?.Properties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalDetail.Properties)
+                {
+                    operationHolder.Telemetry.Properties.Add(property);
+                }
+            }
+
+            if (additionalDetail?.Metrics != null)
+            {
+                foreach (KeyValuePair<string, double> metric in additionalDetail.Metrics)
+                {
+                    operationHolder.Telemetry.Metrics.Add(metric);
+                }
+            }
+
+            return new Operation(operationHolder);
         }
 
         private class Operation : IOperationInstance

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/AdditionalInstrumentationDetail.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/AdditionalInstrumentationDetail.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="AdditionalInstrumentationDetail.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Monitoring.Instrumentation
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Additional information supplied with instrumentation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each of the supported instrumentation types can have additional information attached -
+    /// key value pairs that are either strings or numbers.
+    /// </para>
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage",
+        "CA2227:Collection properties should be read only",
+        Justification = "TODO: needs some thought - we want it to be possible for either property to be null, and we want object initializer syntax to work so I'm not sure I agree with this warning")]
+    public class AdditionalInstrumentationDetail
+    {
+        /// <summary>
+        /// Gets or sets the dictionary of string properties to associate with some instrumentation.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dictionary of numeric properties to associate with some instrumentation.
+        /// </summary>
+        public IDictionary<string, double> Metrics { get; set; }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IExceptionsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IExceptionsInstrumentation.cs
@@ -22,6 +22,7 @@ namespace Corvus.Monitoring.Instrumentation
         /// Report an exception.
         /// </summary>
         /// <param name="x">The exception that occurred.</param>
-        void ReportException(Exception x);
+        /// <param name="additionalDetail">Optional additional properties and metrics.</param>
+        void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail = null);
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
@@ -11,9 +11,9 @@ namespace Corvus.Monitoring.Instrumentation
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When you call <see cref="IOperationsInstrumentation.StartOperation(string)"/>, it returns
-    /// an implementation of this interface. You should dispose it when the operation completes.
-    /// So the normal usage model would look something like this:
+    /// When you call <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>,
+    /// it returns an implementation of this interface. You should dispose it when the operation
+    /// completes. So the normal usage model would look something like this:
     /// </para>
     /// <code>
     /// <![CDATA[

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationsInstrumentation.cs
@@ -20,10 +20,11 @@ namespace Corvus.Monitoring.Instrumentation
         /// Reports that a new operation has started.
         /// </summary>
         /// <param name="name">A short, descriptive operation name.</param>
+        /// <param name="otherDetail">Optional additional properties and metrics.</param>
         /// <returns>
         /// An <see cref="IOperationInstance"/> that must be disposed once this operation
         /// completes.
         /// </returns>
-        IOperationInstance StartOperation(string name);
+        IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail otherDetail = null);
     }
 }


### PR DESCRIPTION
This provides a holder for additional detail. It can hold key/value pairs, either in string or numeric form.

This enables us to attach custom data to instrumentation records, a feature Application Insights supports for all the telemetry types it offers.

Resolves #3 