### PR TITLE
Add fallback instrumentation implementations

### DIFF
--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/FakeInstrumentationSinks.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/FakeInstrumentationSinks.cs
@@ -1,0 +1,112 @@
+﻿namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
+{
+    using System;
+    using System.Collections.Generic;
+    using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Provides fake implementations of the generic and non-generic instrumentation interfaces to
+    /// tests that need them.
+    /// </summary>
+    public class FakeInstrumentationSinks
+    {
+        private readonly List<OperationDetail> operations = new List<OperationDetail>();
+        private readonly List<ExceptionDetail> exceptions = new List<ExceptionDetail>();
+        private readonly List<OperationDetail> genericOperations = new List<OperationDetail>();
+        private readonly List<ExceptionDetail> genericExceptions = new List<ExceptionDetail>();
+
+        /// <summary>
+        /// Gets a list of the operations supplied to the underyling (non-generic) fake
+        /// <see cref="IOperationsInstrumentation"/> implementation.
+        /// </summary>
+        public IReadOnlyList<OperationDetail> Operations => this.operations;
+
+        /// <summary>
+        /// Gets a list of the exceptions supplied to the underyling (non-generic) fake
+        /// <see cref="IExceptionsInstrumentation"/> implementation.
+        /// </summary>
+        public IReadOnlyList<ExceptionDetail> Exceptions => this.exceptions;
+
+        /// <summary>
+        /// Gets a list of the operations supplied to the fake generic
+        /// <see cref="IOperationsInstrumentation{T}"/> implementation.
+        /// </summary>
+        public IReadOnlyList<OperationDetail> GenericOperations => this.genericOperations;
+
+        /// <summary>
+        /// Gets a list of the operations supplied to the fake generic
+        /// <see cref="IExceptionsInstrumentation{T}"/> implementation.
+        /// </summary>
+        public IReadOnlyList<ExceptionDetail> GenericExceptions => this.genericExceptions;
+
+        public void AddNonGenericImplementationsToServices(IServiceCollection services)
+        {
+            services
+                .AddSingleton(this)
+                .AddSingleton<IOperationsInstrumentation, OperationsTarget>()
+                .AddSingleton<IExceptionsInstrumentation, ExceptionsTarget>();
+        }
+
+        public void AddGenericImplementationsToServices(IServiceCollection services)
+        {
+            services
+                .AddSingleton(this)
+                .AddSingleton(typeof(IOperationsInstrumentation<>), typeof(GenericOperationsTarget<>))
+                .AddSingleton(typeof(IExceptionsInstrumentation<>), typeof(GenericExceptionsTarget<>));
+        }
+
+        private class OperationsTargetBase<T> : IOperationsInstrumentation<T>
+        {
+            private readonly List<OperationDetail> operationsList;
+
+            public OperationsTargetBase(List<OperationDetail> operationsList)
+            {
+                this.operationsList = operationsList;
+            }
+
+            public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail additionalDetail = null)
+            {
+                var op = new OperationDetail(name, additionalDetail);
+                this.operationsList.Add(op);
+                return op;
+            }
+        }
+
+        private class OperationsTarget : OperationsTargetBase<object>
+        {
+            public OperationsTarget(FakeInstrumentationSinks parent) : base(parent.operations) { }
+        }
+
+        private class GenericOperationsTarget<T> : OperationsTargetBase<T>
+        {
+            public GenericOperationsTarget(FakeInstrumentationSinks parent) : base(parent.genericOperations) { }
+        }
+
+
+        private class ExceptionsTargetBase<T> : IExceptionsInstrumentation<T>
+        {
+            private readonly List<ExceptionDetail> exceptionsList;
+
+            public ExceptionsTargetBase(List<ExceptionDetail> exceptionsList)
+            {
+                this.exceptionsList = exceptionsList;
+            }
+
+            public void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail = null)
+            {
+                this.exceptionsList.Add(new ExceptionDetail(x, additionalDetail));
+            }
+        }
+
+        private class ExceptionsTarget : ExceptionsTargetBase<object>
+        {
+            public ExceptionsTarget(FakeInstrumentationSinks parent) : base(parent.exceptions) { }
+        }
+
+        private class GenericExceptionsTarget<T> : ExceptionsTargetBase<T>
+        {
+            public GenericExceptionsTarget(FakeInstrumentationSinks parent) : base(parent.genericExceptions) { }
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/ExceptionDetail.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/ExceptionDetail.cs
@@ -1,0 +1,34 @@
+﻿namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes
+{
+    using System;
+
+    /// <summary>
+    /// Describes exception instrumentation that was delivered to one of our fakes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This represents a single call to <see cref="IExceptionsInstrumentation.ReportException(Exception, AdditionalInstrumentationDetail)"/>.
+    /// </para>
+    /// </remarks>
+    public class ExceptionDetail
+    {
+        public ExceptionDetail(
+            Exception x,
+            AdditionalInstrumentationDetail additionalDetail)
+        {
+            this.Exception = x;
+            this.AdditionalDetail = additionalDetail;
+        }
+
+        /// <summary>
+        /// Gets the exception passed to the call to <see cref="IExceptionsInstrumentation.ReportException(Exception, AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Gets the additional instrumentation detail (if any) passed to the call to
+        /// <see cref="IExceptionsInstrumentation.ReportException(Exception, AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public AdditionalInstrumentationDetail AdditionalDetail { get; }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/OperationDetail.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/OperationDetail.cs
@@ -1,0 +1,61 @@
+﻿namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes operation instrumentation that was delivered to one of our fakes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This represents a single call to <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>.
+    /// (It also acts as the return value from that call.)
+    /// </para>
+    /// </remarks>
+    public class OperationDetail : IOperationInstance
+    {
+        private readonly List<AdditionalInstrumentationDetail> furtherDetails = new List<AdditionalInstrumentationDetail>();
+
+        public OperationDetail(
+            string name,
+            AdditionalInstrumentationDetail additionalDetail)
+        {
+            this.Name = name;
+            this.AdditionalDetail = additionalDetail;
+        }
+
+        /// <summary>
+        /// Gets the operation name passed to the call to <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the additional instrumentation detail (if any) passed to the call to
+        /// <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public AdditionalInstrumentationDetail AdditionalDetail { get; }
+
+        /// <summary>
+        /// Gets a list of any further instrumentation detail provided by calls to
+        /// <see cref="IOperationInstance.AddOperationDetail(AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public IReadOnlyList<AdditionalInstrumentationDetail> FurtherDetails => this.furtherDetails;
+
+        /// <summary>
+        /// Gets a value indicating whether the code providing instrumentation to our fake has
+        /// called <c>Dispose</c> on the object returned by 
+        /// <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        void IOperationInstance.AddOperationDetail(AdditionalInstrumentationDetail detail)
+        {
+            this.furtherDetails.Add(detail);
+        }
+
+        void IDisposable.Dispose()
+        {
+            this.IsDisposed = true;
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/FallbackInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/FallbackInstrumentationSpecs.cs
@@ -1,0 +1,141 @@
+﻿namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
+{
+    using System;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Ensure that fallback 'do nothing' instrumentation implementations are available by default,
+    /// but that they don't interfere when apps decide to take control of their own configuration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// There are essentially two goals here.
+    /// </para>
+    /// <para>
+    /// First, we want to ensure that components are free to take a dependency on Corvus.Monitoring
+    /// without imposing a burden on applications that use those components. For example, we want
+    /// Menes to be able to use it, and for that decision not to mean that anyone using Menes is
+    /// forced to make a bunch of decisions about how to configure instrumentation and telemetry
+    /// before they can get started. Menes should be able to call
+    /// <see cref="InstrumentationServiceCollectionExtensions.AddInstrumentation"/> in its own DI
+    /// initialization, with the effect that applications using Menes can be written in blissful
+    /// ignorance of the very existence of Corvus.Monitoring.
+    /// </para>
+    /// <para>
+    /// Second, we want applications that are fully aware of Corvus.Monitoring to be able to fully
+    /// control it even when they are using some other framework that called
+    /// <see cref="InstrumentationServiceCollectionExtensions.AddInstrumentation"/>. The fact that
+    /// a component that depends on Corvus.Monitoring has ensured that a bunch of default
+    /// implementations are automatically in place must not get in the way of an application's
+    /// decision to configure Corvus.Monitoring in any way they please. The fallbacks need to
+    /// ensure that they get well out of the way when they are not needed.
+    /// </para>
+    /// </remarks>
+    public class FallbackInstrumentationSpecs
+    {
+        private ServiceCollection services;
+        private IExceptionsInstrumentation<TestSource> exceptionsInstrumentation;
+        private IOperationsInstrumentation<TestSource> operationsInstrumentation;
+        private FakeInstrumentationSinks fakeInstrumentationSinks;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.services = new ServiceCollection();
+            this.fakeInstrumentationSinks = new FakeInstrumentationSinks();
+        }
+
+        [Test]
+        public void WhenAddInstrumentationCalledAloneGenericImplementationsCanBeResolvedAndUsedWithoutError()
+        {
+            this.services.AddInstrumentation();
+            this.ResolveAndUseAll();
+
+            // In this scenario, we expect everything to go into the bit bucket, which is why there
+            // are no tests to check that the information went anywhere in this case.
+        }
+
+        [Test]
+        public void WhenAddInstrumentationCalledAfterNonGenericImplementationsAddedPresuppliedImplementationsAreUsed()
+        {
+            this.fakeInstrumentationSinks.AddNonGenericImplementationsToServices(this.services);
+            this.services.AddInstrumentation();
+
+            this.ResolveAndCheckInstrumentationReachesSuppliedNonGenericImplementation();
+        }
+
+        [Test]
+        public void WhenAddInstrumentationCalledBeforeNonGenericImplementationsAddedPresuppliedImplementationsAreUsed()
+        {
+            this.services.AddInstrumentation();
+            this.fakeInstrumentationSinks.AddNonGenericImplementationsToServices(this.services);
+
+            this.ResolveAndCheckInstrumentationReachesSuppliedNonGenericImplementation();
+        }
+
+        [Test]
+        public void WhenAddInstrumentationCalledAfterGenericImplementationsAddedPresuppliedImplementationsAreUsed()
+        {
+            this.fakeInstrumentationSinks.AddGenericImplementationsToServices(this.services);
+            this.services.AddInstrumentation();
+
+            this.ResolveAndCheckInstrumentationReachesSuppliedGenericImplementation();
+        }
+
+        [Test]
+        public void WhenAddInstrumentationCalledBeforeGenericImplementationsAddedPresuppliedImplementationsAreUsed()
+        {
+            this.services.AddInstrumentation();
+            this.fakeInstrumentationSinks.AddGenericImplementationsToServices(this.services);
+
+            this.ResolveAndCheckInstrumentationReachesSuppliedGenericImplementation();
+        }
+
+        private void ResolveAndCheckInstrumentationReachesSuppliedNonGenericImplementation()
+        {
+            this.ResolveAndUseAll();
+
+            Assert.AreEqual(1, this.fakeInstrumentationSinks.Operations.Count, "Operations.Count");
+            Assert.AreEqual(1, this.fakeInstrumentationSinks.Exceptions.Count, "Exceptions.Count");
+        }
+
+        private void ResolveAndCheckInstrumentationReachesSuppliedGenericImplementation()
+        {
+            this.ResolveAndUseAll();
+
+            Assert.AreEqual(1, this.fakeInstrumentationSinks.GenericOperations.Count, "GenericOperations.Count");
+            Assert.AreEqual(1, this.fakeInstrumentationSinks.GenericExceptions.Count, "GenericExceptions.Count");
+
+            Assert.AreEqual(0, this.fakeInstrumentationSinks.Operations.Count, "Operations.Count");
+            Assert.AreEqual(0, this.fakeInstrumentationSinks.Exceptions.Count, "Exceptions.Count");
+        }
+
+        private void ResolveAndUseAll()
+        {
+            this.ResolveAll();
+
+            using (this.operationsInstrumentation.StartOperation("Foo"))
+            {
+            }
+
+            this.exceptionsInstrumentation.ReportException(new Exception("Uh oh"));
+        }
+
+        private void ResolveAll()
+        {
+            IServiceProvider sp = this.services.BuildServiceProvider();
+
+            Get(ref this.exceptionsInstrumentation);
+            Get(ref this.operationsInstrumentation);
+
+            void Get<T>(ref T target) { target = sp.GetRequiredService<T>(); }
+        }
+
+        // This class exists purely to be the type argument for the various instrumentation
+        // interfaces.
+        private class TestSource
+        {
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingExceptionsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingExceptionsInstrumentationSpecs.cs
@@ -1,6 +1,7 @@
 namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 {
     using System;
+    using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
     using NUnit.Framework;
 
     public class SourceTaggingExceptionsInstrumentationSpecs : SourceTaggingSpecsBase
@@ -11,14 +12,14 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
         [Test]
         public void WhenExceptionWithNoAdditionalInfoIsSentItShouldIncludeSource()
         {
-            SourceTaggingTestContext.ExceptionDetail ex1Detail = this.ThrowReportAndCatchException1();
+            ExceptionDetail ex1Detail = this.ThrowReportAndCatchException1();
 
             IExceptionsInstrumentation<TestType2> exi2 = this.Context.GetExceptionsInstrumentation<TestType2>();
             var ex2 = new Exception("Another");
             exi2.ReportException(ex2);
 
             Assert.AreEqual(2, this.Context.Exceptions.Count, "Exception count");
-            SourceTaggingTestContext.ExceptionDetail ex2Detail = this.Context.Exceptions[1];
+            ExceptionDetail ex2Detail = this.Context.Exceptions[1];
             Assert.AreSame(ex2, ex2Detail.Exception, "Exception (2)");
 
             Assert.AreEqual(1, ex1Detail.AdditionalDetail?.Properties.Count, "Property count (1)");
@@ -32,7 +33,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
         public void WhenExceptionWithAdditionalInfoWithNoPropertiesOrMetricsIsSentItShouldIncludeSource()
         {
             var suppliedDetail = new AdditionalInstrumentationDetail();
-            SourceTaggingTestContext.ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
+            ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
 
             Assert.AreEqual(1, exDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, exDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -46,7 +47,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
                 Properties = { { ExistingDetailKey, ExistingDetailValue } },
                 Metrics = { { "m1", 42.0 } }
             };
-            SourceTaggingTestContext.ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
+            ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
 
             Assert.AreEqual(2, exDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, exDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -61,7 +62,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
                 Properties = { { ExistingDetailKey, ExistingDetailValue } },
                 Metrics = { { "m1", 42.0 } }
             };
-            SourceTaggingTestContext.ExceptionDetail opDetail = this.ThrowReportAndCatchException1(suppliedDetail);
+            ExceptionDetail opDetail = this.ThrowReportAndCatchException1(suppliedDetail);
 
             Assert.AreSame(suppliedDetail.Metrics, opDetail.AdditionalDetail.Metrics);
         }
@@ -90,7 +91,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             {
                 Properties = { { ExistingDetailKey, ExistingDetailValue } }
             };
-            SourceTaggingTestContext.ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
+            ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
 
             Assert.AreEqual(2, exDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, exDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -104,13 +105,13 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             {
                 Properties = { { ExistingDetailKey, ExistingDetailValue } }
             };
-            SourceTaggingTestContext.ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
+            ExceptionDetail exDetail = this.ThrowReportAndCatchException1(suppliedDetail);
 
             Assert.IsNull(exDetail.AdditionalDetail.MetricsIfPresent);
         }
 
 
-        private SourceTaggingTestContext.ExceptionDetail ThrowReportAndCatchException1(
+        private ExceptionDetail ThrowReportAndCatchException1(
             AdditionalInstrumentationDetail additionalDetail = null)
         {
             IExceptionsInstrumentation<TestType1> exi1 = this.Context.GetExceptionsInstrumentation<TestType1>();
@@ -127,7 +128,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             }
 
             Assert.AreEqual(1, this.Context.Exceptions.Count, "Exception count");
-            SourceTaggingTestContext.ExceptionDetail exDetail = this.Context.Exceptions[0];
+            ExceptionDetail exDetail = this.Context.Exceptions[0];
 
             Assert.AreSame(ax, exDetail.Exception, "Exception");
             return exDetail;

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingOperationsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingOperationsInstrumentationSpecs.cs
@@ -1,5 +1,6 @@
 namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 {
+    using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
     using NUnit.Framework;
 
     public class SourceTaggingOperationsInstrumentationSpecs : SourceTaggingSpecsBase
@@ -12,7 +13,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
         [Test]
         public void WhenOperationWithNoAdditionalInfoIsSentItShouldIncludeSource()
         {
-            SourceTaggingTestContext.OperationDetail op1Detail = this.ReportOperation1();
+            OperationDetail op1Detail = this.ReportOperation1();
 
             IOperationsInstrumentation<TestType2> opi2 = this.Context.GetOperationsInstrumentation<TestType2>();
             using (opi2.StartOperation(OpName2))
@@ -20,7 +21,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             }
 
             Assert.AreEqual(2, this.Context.Operations.Count, "Operation count");
-            SourceTaggingTestContext.OperationDetail op2Detail = this.Context.Operations[1];
+            OperationDetail op2Detail = this.Context.Operations[1];
             Assert.AreEqual(OpName2, op2Detail.Name, "Name (2)");
 
             Assert.AreEqual(1, op1Detail.AdditionalDetail?.Properties.Count, "Property count (1)");
@@ -34,7 +35,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
         public void WhenOperationWithAdditionalInfoWithNoPropertiesOrMetricsIsSentItShouldIncludeSource()
         {
             var suppliedDetail = new AdditionalInstrumentationDetail();
-            SourceTaggingTestContext.OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
+            OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
 
             Assert.AreEqual(1, opDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, opDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -48,7 +49,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
                 Properties = { { ExistingDetailKey, ExistingDetailValue } },
                 Metrics = { { "m1", 42.0 } }
             };
-            SourceTaggingTestContext.OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
+            OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
 
             Assert.AreEqual(2, opDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, opDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -63,7 +64,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
                 Properties = { { ExistingDetailKey, ExistingDetailValue } },
                 Metrics = { { "m1", 42.0 } }
             };
-            SourceTaggingTestContext.OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
+            OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
 
             Assert.AreSame(suppliedDetail.Metrics, opDetail.AdditionalDetail.Metrics);
         }
@@ -92,7 +93,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             {
                 Properties = { { ExistingDetailKey, ExistingDetailValue } }
             };
-            SourceTaggingTestContext.OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
+            OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
 
             Assert.AreEqual(2, opDetail.AdditionalDetail?.Properties.Count, "Property count");
             Assert.AreEqual(typeof(TestType1).FullName, opDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source");
@@ -106,7 +107,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             {
                 Properties = { { ExistingDetailKey, ExistingDetailValue } }
             };
-            SourceTaggingTestContext.OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
+            OperationDetail opDetail = this.ReportOperation1(suppliedDetail);
 
             Assert.IsNull(opDetail.AdditionalDetail.MetricsIfPresent);
         }
@@ -118,7 +119,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 
             using (opi1.StartOperation(OpName1))
             {
-                SourceTaggingTestContext.OperationDetail opDetail = this.Context.Operations[0];
+                OperationDetail opDetail = this.Context.Operations[0];
                 Assert.IsFalse(opDetail.IsDisposed);
             }
         }
@@ -131,8 +132,8 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             using (opi1.StartOperation(OpName1))
             {
             }
-            
-            SourceTaggingTestContext.OperationDetail opDetail = this.Context.Operations[0];
+
+            OperationDetail opDetail = this.Context.Operations[0];
             Assert.IsTrue(opDetail.IsDisposed);
         }
 
@@ -158,7 +159,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
                 op.AddOperationDetail(furtherDetail2);
             }
 
-            SourceTaggingTestContext.OperationDetail opDetail = this.Context.Operations[0];
+            OperationDetail opDetail = this.Context.Operations[0];
             Assert.AreEqual(2, opDetail.FurtherDetails.Count, "FurtherDetails.Count");
 
             Assert.AreSame(furtherDetail1, opDetail.FurtherDetails[0], "FurtherDetails[0]");
@@ -180,7 +181,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             Assert.AreEqual(99.0, furtherDetail2.Metrics["m2"]);
         }
 
-        private SourceTaggingTestContext.OperationDetail ReportOperation1(AdditionalInstrumentationDetail suppliedDetail = null)
+        private OperationDetail ReportOperation1(AdditionalInstrumentationDetail suppliedDetail = null)
         {
             IOperationsInstrumentation<TestType1> opi1 = this.Context.GetOperationsInstrumentation<TestType1>();
 
@@ -189,7 +190,7 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             }
 
             Assert.AreEqual(1, this.Context.Operations.Count, "Operation count");
-            SourceTaggingTestContext.OperationDetail opDetail = this.Context.Operations[0];
+            OperationDetail opDetail = this.Context.Operations[0];
 
             Assert.AreEqual(OpName1, opDetail.Name, "Name");
             return opDetail;

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingTestContext.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingTestContext.cs
@@ -2,29 +2,27 @@
 {
     using System;
     using System.Collections.Generic;
+    using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
     using Microsoft.Extensions.DependencyInjection;
 
     public class SourceTaggingTestContext : IDisposable
     {
         private readonly ServiceProvider serviceProvider;
-        private readonly List<OperationDetail> operations = new List<OperationDetail>();
-        private readonly List<ExceptionDetail> exceptions = new List<ExceptionDetail>();
+        private readonly FakeInstrumentationSinks fakeInstrumentationSinks = new FakeInstrumentationSinks();
 
         public SourceTaggingTestContext()
         {
             var services = new ServiceCollection();
-            services
-                .AddInstrumentationSourceTagging()
-                .AddSingleton<IOperationsInstrumentation>(new OperationsTarget(this))
-                .AddSingleton<IExceptionsInstrumentation>(new ExceptionsTarget(this));
+            services.AddInstrumentationSourceTagging();
+            this.fakeInstrumentationSinks.AddNonGenericImplementationsToServices(services);
             this.serviceProvider = services.BuildServiceProvider();
         }
 
         public string SourcePropertyName => "Category"; // TBD: parameterise tests so we can vary this
 
-        public IReadOnlyList<OperationDetail> Operations => this.operations;
+        public IReadOnlyList<OperationDetail> Operations => this.fakeInstrumentationSinks.Operations;
 
-        public IReadOnlyList<ExceptionDetail> Exceptions => this.exceptions;
+        public IReadOnlyList<ExceptionDetail> Exceptions => this.fakeInstrumentationSinks.Exceptions;
 
         public IOperationsInstrumentation<T> GetOperationsInstrumentation<T>() => this.serviceProvider.GetRequiredService<IOperationsInstrumentation<T>>();
         
@@ -33,82 +31,6 @@
         public void Dispose()
         {
             this.serviceProvider.Dispose();
-        }
-
-        private class OperationsTarget : IOperationsInstrumentation
-        {
-            private readonly SourceTaggingTestContext context;
-
-            public OperationsTarget(SourceTaggingTestContext context)
-            {
-                this.context = context;
-            }
-
-            public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail additionalDetail = null)
-            {
-                var op = new OperationDetail(name, additionalDetail);
-                this.context.operations.Add(op);
-                return op;
-            }
-        }
-
-        private class ExceptionsTarget : IExceptionsInstrumentation
-        {
-            private readonly SourceTaggingTestContext context;
-
-            public ExceptionsTarget(SourceTaggingTestContext context)
-            {
-                this.context = context;
-            }
-
-            public void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail = null)
-            {
-                this.context.exceptions.Add(new ExceptionDetail(x, additionalDetail));
-            }
-        }
-
-        public class OperationDetail : IOperationInstance
-        {
-            private readonly List<AdditionalInstrumentationDetail> furtherDetails = new List<AdditionalInstrumentationDetail>();
-
-            public OperationDetail(
-                string name,
-                AdditionalInstrumentationDetail additionalDetail)
-            {
-                this.Name = name;
-                this.AdditionalDetail = additionalDetail;
-            }
-
-            public string Name { get; }
-
-            public AdditionalInstrumentationDetail AdditionalDetail { get; }
-            public IReadOnlyList<AdditionalInstrumentationDetail> FurtherDetails => this.furtherDetails;
-
-            public bool IsDisposed { get; private set; }
-
-            void IOperationInstance.AddOperationDetail(AdditionalInstrumentationDetail detail)
-            {
-                this.furtherDetails.Add(detail);
-            }
-
-            void IDisposable.Dispose()
-            {
-                this.IsDisposed = true;
-            }
-        }
-
-        public class ExceptionDetail
-        {
-            public ExceptionDetail(
-                Exception x,
-                AdditionalInstrumentationDetail additionalDetail)
-            {
-                this.Exception = x;
-                this.AdditionalDetail = additionalDetail;
-            }
-
-            public Exception Exception { get; }
-            public AdditionalInstrumentationDetail AdditionalDetail { get; }
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullExceptionsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullExceptionsInstrumentation.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="NullExceptionsInstrumentation.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Monitoring.Instrumentation
+{
+    using System;
+
+    /// <summary>
+    /// Fallback do-nothing sink for exception instrumentation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This gets used when an application uses some library or framework that uses
+    /// Corvus.Monitoring, but where the application doesn't want to do anything with the
+    /// information.
+    /// </para>
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "This warning does not recognize usage through DI")]
+    internal class NullExceptionsInstrumentation : IExceptionsInstrumentation
+    {
+        /// <inheritdoc/>
+        public void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail = null)
+        {
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="NullOperationsInstrumentation.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Monitoring.Instrumentation
+{
+    /// <summary>
+    /// Fallback do-nothing sink for operations instrumentation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This gets used when an application uses some library or framework that uses
+    /// Corvus.Monitoring, but where the application doesn't want to do anything with the
+    /// information.
+    /// </para>
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "This warning does not recognize usage through DI")]
+    internal class NullOperationsInstrumentation : IOperationsInstrumentation
+    {
+        /// <inheritdoc/>
+        public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail additionalDetail = null)
+        {
+            return Operation.Instance;
+        }
+
+        private class Operation : IOperationInstance
+        {
+            public static readonly Operation Instance = new Operation();
+
+            public void AddOperationDetail(AdditionalInstrumentationDetail detail)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Microsoft/Extensions/DependencyInjection/InstrumentationServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Microsoft/Extensions/DependencyInjection/InstrumentationServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    using System;
     using Corvus.Monitoring.Instrumentation;
 
     /// <summary>
@@ -11,6 +12,77 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class InstrumentationServiceCollectionExtensions
     {
+        /// <summary>
+        /// Ensure that the various instrumentation interfaces can all be resolved successfully
+        /// through DI.
+        /// </summary>
+        /// <param name="services">The service collection to which to add the services.</param>
+        /// <returns>The service collection.</returns>
+        /// <remarks>
+        /// <para>
+        /// If an application performs no other instrumentation setup, the instrumentation
+        /// implementations available will all do nothing. The intent of this is to enable
+        /// libraries to presume that these interfaces are always available, even in applications
+        /// that turn out not to want any of the instrumentation information.
+        /// </para>
+        /// <para>
+        /// Applications that want to take advantage of instrumentation should register
+        /// implementations of the non-generic interfaces either before or after this method is
+        /// called. (E.g., they could take a dependency on Corvus.Monitoring.ApplicationInsights
+        /// and call <c>AddApplicationInsightsInstrumentationTelemetry</c> in their DI startup.)
+        /// Doing so either before or after calling this method will result in that real
+        /// implementation being used instead of the null implementations this method provides as
+        /// fallbacks.
+        /// </para>
+        /// </remarks>
+        public static IServiceCollection AddInstrumentation(
+            this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            bool operationsAlreadyPresent = false;
+            bool exceptionsAlreadyPresent = false;
+            bool genericImplementationAlreadyPresent = false;
+            foreach (ServiceDescriptor service in services)
+            {
+                if (service.ServiceType == typeof(IOperationsInstrumentation))
+                {
+                    operationsAlreadyPresent = true;
+                }
+
+                if (service.ServiceType == typeof(IExceptionsInstrumentation))
+                {
+                    exceptionsAlreadyPresent = true;
+                }
+
+                if (service.ServiceType == typeof(IOperationsInstrumentation<>) ||
+                    service.ServiceType == typeof(IExceptionsInstrumentation<>))
+                {
+                    genericImplementationAlreadyPresent = true;
+                }
+            }
+
+            if (!operationsAlreadyPresent)
+            {
+                services.AddSingleton<IOperationsInstrumentation, NullOperationsInstrumentation>();
+            }
+
+            if (!exceptionsAlreadyPresent)
+            {
+                services.AddSingleton<IExceptionsInstrumentation, NullExceptionsInstrumentation>();
+            }
+
+            if (!genericImplementationAlreadyPresent)
+            {
+                services.AddInstrumentationSourceTagging();
+            }
+
+            return services;
+        }
+
         /// <summary>
         /// Add implementations of the generic instrumentation interfaces that add information
         /// based on the generic type argument.


### PR DESCRIPTION
This adds 'null' implementations of the non-generic instrumentation interfaces that do nothing. This means that any library or framework can use `Corvus.Monitoring` without forcing the hosting application to set anything up—if the host app isn't interested in any of the data the instrumentation can provide, it can' completely ignore it. As long as the framework does this:

```csharp
services.AddInstrumentation();
```

somewhere in its own DI setup, null objects for all the various instrumentation targets will be supplied.

If the application registers other implementations either before or after that call occurs, they will replace these fallback ones.

Resolves #13.