### PR TITLE
Enable use of TelemetryClient via DI

### DIFF
--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiSpecsBase.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiSpecsBase.cs
@@ -11,6 +11,21 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
     /// </summary>
     public abstract class AiSpecsBase
     {
+        private readonly bool telemetryClientViaDi;
+
+        /// <summary>
+        /// Creates a <see cref="AiSpecsBase"/>.
+        /// </summary>
+        /// <param name="telemetryClientViaDi">
+        /// Pass <c>true</c> to use the DI initialization mechanism in which the Application Insights
+        /// <c>TelemetryClient</c> is obtained through DI. Pass <c>false</c> to use the mechanism in
+        /// which it is not available via DI and is instead passed in directly during initialization.
+        /// </param>
+        protected AiSpecsBase(bool telemetryClientViaDi = false)
+        {
+            this.telemetryClientViaDi = telemetryClientViaDi;
+        }
+
         /// <summary>
         /// Gets the <see cref="AiTestContext"/>.
         /// </summary>
@@ -28,7 +43,7 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
         [SetUp]
         public void Setup()
         {
-            this.Ai = new AiTestContext();
+            this.Ai = new AiTestContext(this.telemetryClientViaDi);
         }
 
         /// <summary>

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiTestContext.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiTestContext.cs
@@ -24,7 +24,12 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
         /// <summary>
         /// Creates a <see cref="AiTestContext"/>.
         /// </summary>
-        public AiTestContext()
+        /// <param name="telemetryClientViaDi">
+        /// Indicates whether to use the DI initialization mechanism that obtains the <see cref="TelemetryClient"/>
+        /// as a dependency. (In general it's preferable not to do that, but the Azure Functions SDK requires it,
+        /// so we support it.)
+        /// </param>
+        public AiTestContext(bool telemetryClientViaDi)
         {
             var items = new List<ITelemetry>();
             this.Items = items;
@@ -35,7 +40,15 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
             this.TelemetryClient = new TelemetryClient(telemetryConfig);
 
             var services = new ServiceCollection();
-            services.AddApplicationInsightsInstrumentationTelemetry(this.TelemetryClient);
+            if (telemetryClientViaDi)
+            {
+                services.AddSingleton(this.TelemetryClient);
+                services.AddApplicationInsightsInstrumentationTelemetry();
+            }
+            else
+            {
+                services.AddApplicationInsightsInstrumentationTelemetry(this.TelemetryClient);
+            }
 
             this.serviceProvider = services.BuildServiceProvider();
 

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>RCS1029;SA0001</NoWarn>
 
     <IsPackable>false</IsPackable>

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/TelemetryClientViaDiSpecs.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/TelemetryClientViaDiSpecs.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="TelemetryClientViaDiSpecs.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Monitoring.ApplicationInsights.Specs
+{
+    using System;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// In general it's preferable not to put the Application Insights <c>TelemetryClient</c> into the DI service
+    /// collection, because that encourages code to depend on it directly, which in turn makes that code resistant
+    /// to enhancements in our monitoring libraries. However, in Azure Functions, that's the only supported way
+    /// to get hold of a correctly-initialized <c>TelemetryClient</c>, so it's a scenario we need to support.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test members are public so the test framework can see them, but they're not intended for public consumption, so they don't require documentation")]
+    public class TelemetryClientViaDiSpecs : AiSpecsBase
+    {
+        public TelemetryClientViaDiSpecs()
+            : base(true)
+        {
+        }
+
+        [Test]
+        public void InstrumentationReportsTelemetryToAiWhenClientObtainedViaDi()
+        {
+            // We're not going to exercise everything. Just perform a basic smoke test, and some
+            // simple verification. The only goal here is to ensure that the alternative DI
+            // initialization mechanims works. We leave the full exercising to all the other tests.
+            ArgumentException ax;
+
+            using (this.Ai.OperationsInstrumentation.StartOperation("ParentOp"))
+            {
+                try
+                {
+                    throw new ArgumentException("That was never 5 minutes!", "duration");
+                }
+                catch (ArgumentException x)
+                {
+                    ax = x;
+                    this.Ai.ExceptionsInstrumentation.ReportException(x);
+                }
+            }
+
+            (ExceptionTelemetry exceptionTelemetry, RequestTelemetry requestTelemetry) = this.Ai.GetParentOperationAndExceptionTelemetry<ExceptionTelemetry, RequestTelemetry>();
+            Assert.AreEqual(this.Ai.Activity.RootId, exceptionTelemetry.Context.Operation.Id);
+            Assert.AreEqual(requestTelemetry.Id, exceptionTelemetry.Context.Operation.ParentId);
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Microsoft/Extensions/DependencyInjection/ApplicationInsightsTelemetryServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Microsoft/Extensions/DependencyInjection/ApplicationInsightsTelemetryServiceCollectionExtensions.cs
@@ -20,6 +20,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The service collection to which to add the services.</param>
         /// <param name="telemetryClient">The Application Insights telemetry client.</param>
         /// <returns>The service collection.</returns>
+        /// <remarks>
+        /// This overload supports scenarios in which the <see cref="TelemetryClient"/> is not
+        /// available via DI. Since the <c>Corvus.Monitoring</c> libraries are designed to allow
+        /// instrumentation to be added to components without depending directly on any particular
+        /// telemetry mechanism, it is often desirable to avoid putting the <c>TelemetryClient</c>
+        /// into the services available via DI. This extension method makes it possible to
+        /// pass the <c>TelemetryClient</c> in to the Application-Insights-specific parts of
+        /// <c>Corvus.Monitoring</c> without putting it into the DI services.
+        /// </remarks>
         public static IServiceCollection AddApplicationInsightsInstrumentationTelemetry(
             this IServiceCollection services,
             TelemetryClient telemetryClient)
@@ -27,6 +36,24 @@ namespace Microsoft.Extensions.DependencyInjection
             return services
                 .AddSingleton<IOperationsInstrumentation>(new AiOperationsInstrumentation(telemetryClient))
                 .AddSingleton<IExceptionsInstrumentation>(new AiExceptionsInstrumentation(telemetryClient));
+        }
+
+        /// <summary>
+        /// Adds services to deliver Instrumentation telemetry to Application Insights.
+        /// </summary>
+        /// <param name="services">The service collection to which to add the services.</param>
+        /// <returns>The service collection.</returns>
+        /// <remarks>
+        /// This overload supports scenarios in which the <see cref="TelemetryClient"/> must be
+        /// obtained via DI. For example, the Azure Functions SDK makes the <c>TelemetryClient</c>
+        /// available only through DI.
+        /// </remarks>
+        public static IServiceCollection AddApplicationInsightsInstrumentationTelemetry(
+            this IServiceCollection services)
+        {
+            return services
+                .AddSingleton<IOperationsInstrumentation, AiOperationsInstrumentation>()
+                .AddSingleton<IExceptionsInstrumentation, AiExceptionsInstrumentation>();
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>RCS1029;SA0001</NoWarn>
 
     <IsPackable>false</IsPackable>

--- a/imm.yaml
+++ b/imm.yaml
@@ -67,7 +67,7 @@
     Id: 6c0402b3-f0e3-4bd7-83fe-04bb6dca7924
     Measures:
         -
-            Score: 2
+            Score: 3
             Description: 'Using the most current LTS version'
 -
     Name: 'Associated Work Items'


### PR DESCRIPTION
Also upgraded tests to .NET Core 3.1 because apparently VS 2019 16.4 broke the ability to run plain NUnit tests against .NET Core 2.1!

Resolves #35