### PR TITLE
Fix source tagging naming issues

### DIFF
--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingExceptionsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingExceptionsInstrumentationSpecs.cs
@@ -1,6 +1,7 @@
 namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 {
     using System;
+    using System.Collections.Generic;
     using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
     using NUnit.Framework;
 
@@ -27,6 +28,20 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 
             Assert.AreEqual(1, ex2Detail.AdditionalDetail?.Properties.Count, "Property count (2)");
             Assert.AreEqual(typeof(TestType2).FullName, ex2Detail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source (1)");
+        }
+
+        [Test]
+        public void WhenSourceTypeIsGenericSourceDoesNotIncludeTypeArguments()
+        {
+            IExceptionsInstrumentation<GenericTestType<string, List<int>>> exig = this.Context.GetExceptionsInstrumentation<GenericTestType<string, List<int>>>();
+            var ex = new Exception("Another");
+            exig.ReportException(ex);
+
+            Assert.AreEqual(1, this.Context.Exceptions.Count, "Exception count");
+            ExceptionDetail exDetail = this.Context.Exceptions[0];
+            Assert.AreSame(ex, exDetail.Exception, "Exception (3)");
+
+            Assert.AreEqual($"{typeof(SourceTaggingSpecsBase).Namespace}.{nameof(SourceTaggingSpecsBase)}+{nameof(GenericTestType<string, List<int>>)}", exDetail.AdditionalDetail.Properties[this.Context.SourcePropertyName], "Source (2)");
         }
 
         [Test]

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingSpecsBase.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingSpecsBase.cs
@@ -44,5 +44,9 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
         public class TestType2
         {
         }
+
+        public class GenericTestType<T1, T2>
+        {
+        }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingTestContext.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingTestContext.cs
@@ -18,7 +18,7 @@
             this.serviceProvider = services.BuildServiceProvider();
         }
 
-        public string SourcePropertyName => "Category"; // TBD: parameterise tests so we can vary this
+        public string SourcePropertyName => "Endjin.Source"; // TBD: parameterise tests so we can vary this
 
         public IReadOnlyList<OperationDetail> Operations => this.fakeInstrumentationSinks.Operations;
 

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/TaggingPropertySource.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/TaggingPropertySource.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Monitoring.Instrumentation
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -43,9 +44,43 @@ namespace Corvus.Monitoring.Instrumentation
             {
                 Properties =
                 {
-                    { this.PropertyName, typeof(TSource).FullName },
+                    { this.PropertyName, GetTypeDisplayName(typeof(TSource)) },
                 },
             };
+        }
+
+        /// <summary>
+        /// Ensure type name isn't bonkers when generic.
+        /// </summary>
+        /// <param name="t">The type for which to produce a displayable name.</param>
+        /// <returns>A string representing the type.</returns>
+        /// <remarks>
+        /// <para>
+        /// Although <see cref="Type.FullName"/> works well to identify non-generic types, there's a problem using
+        /// it as a display name for generic types: it produces more or less unreadable strings. This is because the
+        /// full name uses assembly-qualified names for type arguments.
+        /// </para>
+        /// <para>
+        /// The effect is that something as simple as <c>IEnumerable&lt;int&gt;</c> becomes
+        /// <c>System.Collections.Generic.IEnumerable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</c>.
+        /// </para>
+        /// <para>
+        /// While this may be useful for guaranteeing full fidelity (although it seems odd to do that when the main
+        /// type itself is not also qualified) it just makes things unreadable when these strings appear in telemetry.
+        /// So we need a simpler representation. For now, we're just stripping off the type arguments, so the preceding
+        /// example would become <c>System.Collections.Generic.IEnumerable</c>.
+        /// </para>
+        /// </remarks>
+        private static string GetTypeDisplayName(Type t)
+        {
+            if (t.IsGenericType)
+            {
+                string nameWithArity = t.GetGenericTypeDefinition().FullName;
+                int arityMarkerIndex = nameWithArity.LastIndexOf('`');
+                return nameWithArity.Substring(0, arityMarkerIndex);
+            }
+
+            return t.FullName;
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Microsoft/Extensions/DependencyInjection/InstrumentationServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Microsoft/Extensions/DependencyInjection/InstrumentationServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The service collection.</returns>
         public static IServiceCollection AddInstrumentationSourceTagging(
             this IServiceCollection services,
-            string propertyName = "Category")
+            string propertyName = "Endjin.Source")
         {
             return services
                 .AddSingleton(new TaggingPropertySource(propertyName))


### PR DESCRIPTION
* Generic types now produce less crazy names
* The default property name used for tagging no longer conflicts with default Application Insights configuration in Azure Functions

Resolves #38, resolves #39