### PR TITLE
Bump to v1.3 because a v1.2 got released by accident

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.2"
+next-version: "1.3"
 


### PR DESCRIPTION
The 1.2.0 release at https://github.com/corvus-dotnet/Corvus.Monitoring/releases/tag/1.2.0 seems spurious, and seems to be causing our version tagging to fail because we've release 1.1.x versions since then on the main branch.

So I'm bumping to 1.3.0 to get out of this.