### PR TITLE
Use floating versions for System/Microsoft dependencies

### DIFF
--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
@@ -18,11 +18,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.*,)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.2" />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Corvus.Monitoring.ApplicationInsights\Corvus.Monitoring.ApplicationInsights.csproj" />

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.*,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
@@ -18,8 +18,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.16" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.*,)" />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Corvus.Monitoring.Instrumentation.Abstractions\Corvus.Monitoring.Instrumentation.Abstractions.csproj" />

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.*,)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also update to Corvus.Testing 1.4.4 (which also uses floating dependencies)