### PR TITLE
Allow adding additional operation properties/metrics individually

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.3"
+next-version: "2.0"
 

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
@@ -139,7 +139,6 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
             (RequestTelemetry child, RequestTelemetry parent) = this.GetChildParentRequestTelemetry();
 
             Assert.AreNotEqual(parent.Id, child.Id);
-            Assert.IsTrue(child.Id.StartsWith(parent.Id));
 
             // The activity root id should permeate through all telemetry associated
             // with the request. It becomes the ai.operation.id tag, which shows up

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
@@ -118,20 +118,22 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
         [Test]
         public void WhenChildOperationFinishesTelemetryIncludesParentId()
         {
-            string testActivityId = Activity.Current.Id;
-            string parentOpActivityId;
-            string childOpActivityId;
+            string? testActivityId = Activity.Current?.Id;
+            string? parentOpActivityId;
+            string? childOpActivityId;
             using (this.Ai.OperationsInstrumentation.StartOperation("ParentOp"))
             {
-                parentOpActivityId = Activity.Current.Id;
+                parentOpActivityId = Activity.Current?.Id;
                 using (this.Ai.OperationsInstrumentation.StartOperation("ChildOp"))
                 {
-                    childOpActivityId = Activity.Current.Id;
+                    childOpActivityId = Activity.Current?.Id;
                 }
             }
 
             (RequestTelemetry child, RequestTelemetry parent) = this.GetChildParentRequestTelemetry();
 
+            Assert.IsNotNull(parentOpActivityId);
+            Assert.IsNotNull(childOpActivityId);
             Assert.AreNotEqual(parent.Id, child.Id);
             Assert.IsTrue(child.Id.StartsWith(parent.Id));
 

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/AiOperationsInstrumentationSpecs.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Monitoring.ApplicationInsights.Specs
 {
+    using System;
     using System.Diagnostics;
     using Corvus.Monitoring.Instrumentation;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -118,22 +119,25 @@ namespace Corvus.Monitoring.ApplicationInsights.Specs
         [Test]
         public void WhenChildOperationFinishesTelemetryIncludesParentId()
         {
-            string? testActivityId = Activity.Current?.Id;
-            string? parentOpActivityId;
-            string? childOpActivityId;
+            string testActivityId = Activity.Current?.Id
+                ?? throw new InvalidOperationException("Test expects a current Activity");
+
+            string parentOpActivityId;
+            string childOpActivityId;
             using (this.Ai.OperationsInstrumentation.StartOperation("ParentOp"))
             {
-                parentOpActivityId = Activity.Current?.Id;
+                parentOpActivityId = Activity.Current?.Id
+                    ?? throw new InvalidOperationException("Test expects a current Activity");
+
                 using (this.Ai.OperationsInstrumentation.StartOperation("ChildOp"))
                 {
-                    childOpActivityId = Activity.Current?.Id;
+                    childOpActivityId = Activity.Current?.Id
+                        ?? throw new InvalidOperationException("Test expects a current Activity");
                 }
             }
 
             (RequestTelemetry child, RequestTelemetry parent) = this.GetChildParentRequestTelemetry();
 
-            Assert.IsNotNull(parentOpActivityId);
-            Assert.IsNotNull(childOpActivityId);
             Assert.AreNotEqual(parent.Id, child.Id);
             Assert.IsTrue(child.Id.StartsWith(parent.Id));
 

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
          with bindings in SpecFlow.
          Disabling SA1600, SA1602 (all public types and members to be documented) because test projects need to make lots of types

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/Corvus.Monitoring.ApplicationInsights.Specs.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
          with bindings in SpecFlow.
          Disabling SA1600, SA1602 (all public types and members to be documented) because test projects need to make lots of types

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/packages.lock.json
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    "net6.0": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
         "requested": "[1.6.0, )",
@@ -59,7 +59,7 @@
         "resolved": "5.1.0",
         "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
         "dependencies": {
-          "System.Diagnostics.EventLog": "4.7.0"
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "Corvus.Testing.SpecFlow": {
@@ -679,13 +679,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "iDoKGQcRwX0qwY+eAEkaJGae0d/lHlxtslO+t8pJWAUxlvY3tqLtVOPnW2UU4cFjP0Y/L1QBqhkZfSyGqVMR2w==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "3.1.0",
-          "Microsoft.Win32.Registry": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Diagnostics.Process": {
         "type": "Transitive",

--- a/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/packages.lock.json
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights.Specs/packages.lock.json
@@ -4,49 +4,49 @@
     ".NETCoreApp,Version=v3.1": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[1.4.7, )",
-        "resolved": "1.4.7",
-        "contentHash": "Vli4LM72bkDNPZQ06bNS6s47o/4UQd0DuussioE4SP/gyx1CIHfctP83imQKivNqeTdpXNIwV5XM/VPtZL6Hxw==",
+        "requested": "[1.6.0, )",
+        "resolved": "1.6.0",
+        "contentHash": "V8v7+oRFK99skWq/TmzgiiS6KYQtu/gJXTXep8HKxt3u1rbU7BZFQfPCHiyH7KSAIn+4HEnxqlvCbXUSyRGCAA==",
         "dependencies": {
-          "Corvus.Testing.SpecFlow": "1.4.7",
+          "Corvus.Testing.SpecFlow": "1.6.0",
           "Microsoft.NET.Test.Sdk": "16.11.0",
-          "Moq": "4.16.1",
-          "SpecFlow.NUnit.Runners": "3.9.40",
-          "coverlet.msbuild": "3.1.0"
+          "Moq": "4.18.2",
+          "SpecFlow.NUnit.Runners": "3.9.74",
+          "coverlet.msbuild": "3.1.2"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "fPzzi16UfB+Ws7Fhwyn95lTt56uZtIvLjvU/QPRQo4XgefOKzxNshlRxlJbMgNLFMAQecDxzoNMJmjGlqU0gwQ==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.0.1",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.22",
-        "contentHash": "QrzfKU8te2X0ykM8XY9YzLvzTGO8qOMq45/Y2sy5gZryQqYe9CxEr0ulwG0idpL+ByK7luX7djmtT8Nv1mMaZw==",
+        "resolved": "3.1.32",
+        "contentHash": "VUbvtpsoHZf4XtBhsfio0+2cpqC9bJs6ZiApT3G81CwBfcDV5OSeU9SaI6it6wxaGf0K2uADzzIS+4yTADaTRg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.22"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.32"
         }
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[3.3.0, )",
-        "resolved": "3.3.0",
-        "contentHash": "yrX3i1javiCEulgi87ZvvV9nEieyv3tOe79Y978TS2Omwj/FX4pLap58U8A1gyPtQEkMcSzsNIoqLOBf+HfuaA=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
-        "requested": "[1.2.0-beta.376, )",
-        "resolved": "1.2.0-beta.376",
-        "contentHash": "uaaVoOYWfIMoWtZsNJwV0m/GI3XAi8BA71e9iBOFDPo3TtAmcGkZ2qcxItkWb6eKI90urOPmxc35BnuhluC1IA==",
+        "requested": "[1.2.0-beta.435, )",
+        "resolved": "1.2.0-beta.435",
+        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
         "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.376"
+          "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
       "BoDi": {
@@ -56,43 +56,34 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "b5rRL5zeaau1y/5hIbI+6mGw3cwun16YjkHZnV9RRT5UyUIFsgLmNXJ0YnIN9p8Hw7K7AbG1q1UclQVU3DinAQ==",
+        "resolved": "5.1.0",
+        "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "System.Collections.Specialized": "4.3.0",
-          "System.ComponentModel": "4.3.0",
-          "System.ComponentModel.TypeConverter": "4.3.0",
-          "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Xml.XmlDocument": "4.3.0"
+          "System.Diagnostics.EventLog": "4.7.0"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.7",
-        "contentHash": "qGqOQt/9x95MOmUyA57JgNmdWRF1lgKjYEjU9IXw3ElMYs5S93I0qHiqBdQCIDq8qHxkXgo6cnDIJsrBLCrReQ==",
+        "resolved": "1.6.0",
+        "contentHash": "0Qg8suJQ6TbvQK1ND51LK6kP0x1lZfqQVpbLf0CqKcIVLrJLmsb2Az+j635D6RJNTZ6jYcWxxtFEh314bERaMQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.21",
-          "Microsoft.Extensions.DependencyInjection": "3.1.21",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.21",
-          "NUnit": "3.13.2",
-          "SpecFlow": "3.9.40",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.31",
+          "Microsoft.Extensions.DependencyInjection": "3.1.31",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.31",
+          "NUnit": "3.13.3",
+          "SpecFlow": "3.9.74",
           "System.Management": "4.7.0"
         }
       },
       "coverlet.msbuild": {
         "type": "Transitive",
-        "resolved": "3.1.0",
-        "contentHash": "xOv5HZagq0I6uF4vt8NVVpwcA2W/uGmNcbLStao2eMk98RQH5NFPQuouh2nWWPSZrNIhGG/iYbBn2pO4s5i+ig=="
+        "resolved": "3.1.2",
+        "contentHash": "QhM0fnDtmIMImY7oxyQ/kh1VYtRxPyRVeLwRUGuUvI6Xp83pSYG9gerK8WgJj4TzUl7ISziADUGtIWKhtlbkbQ=="
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "dVEeGG6a4hTeu8SOgN3ZJaotbtgjuQjOz7xCIOgPZpwzA1JZWZVhk3nGVfs3LjZwkgGbXH3NlHtid621ryN/Pg==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -179,16 +170,16 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.21",
-        "contentHash": "3Ef65E9wCkGJVPQZ7S7GtDJ8JXpCQ3c2b83XLIOINoVV7GSEjKyW/vycc3jQfdc5BIf/lnjodkDiKnjdTzXAZA==",
+        "resolved": "3.1.31",
+        "contentHash": "apqvGW9hYd5khi23FQilW76SRqxzk3E5KraEQFN84imt0KREsGyUIvBG4vedIMORfdDtxgPaHdfl7vPs6nm5oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.21"
+          "Microsoft.Extensions.Primitives": "3.1.31"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "+zBl4NrqANk4JalElpCZ3P2rQ33A3ldRCF1K7RikOuNzEWG5B2M5C+Izas7q5Ub6bFMzAvCJh5E+BtT/gTUD6Q=="
+        "resolved": "3.1.32",
+        "contentHash": "dARl3iAcHZshMvnXtKpLGES4QZq8ExxIQnF2s8pXfP3MJOOXRSBsk+UmA3TMVN4hPr4O2QFS8AMJp9GDD/4lDw=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -204,8 +195,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.21",
-        "contentHash": "hhfhugCsGsceQTSdHhtvOnzgGKUDMxcGIMU8z4m8HTTb99B0Ujf7gyT6C4/0hA/KocSN3p/Flt54Y1db9N2TiA=="
+        "resolved": "3.1.31",
+        "contentHash": "Ta9FclAg2bt7ay40o8ArAMaHKcyojq0eHzPdvZqe1hr28wGLWMSmqxglx1BGgrvY5H9lYiRrReFHovFYx+dsFQ=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",
@@ -279,11 +270,10 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.16.1",
-        "contentHash": "bw3R9q8cVNhWXNpnvWb0OGP4HadS4zvClq+T1zf7AF+tLY1haZ2AvbHidQekf4PDv1T40c6brZeT/V0IBq7cEQ==",
+        "resolved": "4.18.2",
+        "contentHash": "SjxKYS5nX6prcaT8ZjbkONh3vnh0Rxru09+gQ1a07v4TM530Oe/jq3Q4dOZPfo1wq0LYmTgLOZKrqRfEx4auPw==",
         "dependencies": {
-          "Castle.Core": "4.4.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Castle.Core": "5.1.0"
         }
       },
       "NETStandard.Library": {
@@ -330,8 +320,8 @@
       },
       "NUnit": {
         "type": "Transitive",
-        "resolved": "3.13.2",
-        "contentHash": "u+fz/lXyR4vlamySNAEMrXvh+GhAQiB6/aVZtU5WjivR5zF26Ui0tfteDtWqT90k9D8y6g8rFKYQC97Z7d195w==",
+        "resolved": "3.13.3",
+        "contentHash": "KNPDpls6EfHwC3+nnA67fh5wpxeLb3VLFAfLxrug6JMYDLHH6InaQIWR7Sc3y75d/9IKzMksH/gi08W7XWbmnQ==",
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
@@ -495,8 +485,8 @@
       },
       "SpecFlow": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "ru7twstJSKrTv3XfcxyttzrdZ/FvXOF5cYN/x/2js755wVk1zpSPUPa/ml3lSZmPNkS5OAOuSt1JLEa5hhDhdw==",
+        "resolved": "3.9.74",
+        "contentHash": "n6kcg9ZeQWxqJFoT23SsFT89U1QQNwvcN9pAX5alB6ZPr6K0p5D5nGIJ1PZsSaFaRFutiwQ+DicmxBCPAZVYIA==",
         "dependencies": {
           "BoDi": "1.5.0",
           "Gherkin": "19.0.3",
@@ -514,36 +504,36 @@
       },
       "SpecFlow.NUnit": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "+brbJAe0LLzmXh2L78kOJc2fa5EH/7cugmbnfZQdBeWCzL6iFDWFl3MHZ0xx/2BQyu6N/xokqw53Rl30LIo7lw==",
+        "resolved": "3.9.74",
+        "contentHash": "nMPLztTT5IZDMnvNCUxklqaM+agn4kjuNy/qAcYQQOxau2G1MF73UxhL9OXjJQaEuPuyT8gJvXudOYCFZWztxA==",
         "dependencies": {
           "NUnit": "3.13.1",
-          "SpecFlow": "[3.9.40]",
-          "SpecFlow.Tools.MsBuild.Generation": "[3.9.40]"
+          "SpecFlow": "[3.9.74]",
+          "SpecFlow.Tools.MsBuild.Generation": "[3.9.74]"
         }
       },
       "SpecFlow.NUnit.Runners": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "vScntUGHtokExBWweUG9XOkjTum1B14lP4KU9T2rNW+gIGJBG99YmnR3/NMy4YMfASg5VkGJLx4icpZDYJENsQ==",
+        "resolved": "3.9.74",
+        "contentHash": "m595x3GM7CYco+KsXo96irQ2jcjC6+1+41bKdmnTdl3RAvnC4jUZ9f5B5FhGuaVK4+j4GwWi8MZtGMrT//zHLA==",
         "dependencies": {
           "NUnit.Console": "3.12.0",
           "NUnit3TestAdapter": "3.17.0",
-          "SpecFlow.NUnit": "[3.9.40]"
+          "SpecFlow.NUnit": "[3.9.74]"
         }
       },
       "SpecFlow.Tools.MsBuild.Generation": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "DFClKzQH0ijUBiZNpas8sQ66EdGwVSS18UtC1hVIM7PiT0F+xzKs4VX5hsz+ZY/RKyQEfY9HELUAC8AoZicxSg==",
+        "resolved": "3.9.74",
+        "contentHash": "I/9OvmKOohJqIUNJ0xGYJCWfL6WKDaes8OoOAD/2yhGX+tzC5ofs9yqkP9Cu/xfnIx+11IR3pZs7YhBhGAcgWQ==",
         "dependencies": {
-          "SpecFlow": "[3.9.40]"
+          "SpecFlow": "[3.9.74]"
         }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
-        "resolved": "1.2.0.376",
-        "contentHash": "a009jDRd7zP6h+jenZ7nGjqkkFkEuxmT9FeM334cLDwodfU2x/nNcsFqw2Pjd4wVPiyX+qjLq+vhhbE3OPzFMw=="
+        "resolved": "1.2.0.435",
+        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -687,6 +677,16 @@
         "resolved": "4.5.0",
         "contentHash": "eIHRELiYDQvsMToML81QFkXEEYXUSUT2F28t1SGrevWqP+epFdw80SyAXIKTXOHrIEXReFOEnEr7XlGiC2GgOg=="
       },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "iDoKGQcRwX0qwY+eAEkaJGae0d/lHlxtslO+t8pJWAUxlvY3tqLtVOPnW2UU4cFjP0Y/L1QBqhkZfSyGqVMR2w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.Registry": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
       "System.Diagnostics.Process": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -736,22 +736,6 @@
           "System.Runtime": "4.1.0"
         }
       },
-      "System.Diagnostics.TraceSource": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "runtime.native.System": "4.3.0"
-        }
-      },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -764,23 +748,24 @@
       },
       "System.Dynamic.Runtime": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
+        "resolved": "4.0.11",
+        "contentHash": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Globalization": {
@@ -866,26 +851,26 @@
       },
       "System.Linq.Expressions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
+        "resolved": "4.1.0",
+        "contentHash": "I+y02iqkgmCAyfbqOmSDOgqdZQ5tTj80Akm5BPSS8EeB0VGWdy6X1KCoYe8Pk6pwDoAKZUOdLVxnTJcExiv5zw==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Management": {
@@ -975,14 +960,14 @@
       },
       "System.ObjectModel": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
+        "resolved": "4.0.12",
+        "contentHash": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Reflection": {
@@ -999,35 +984,35 @@
       },
       "System.Reflection.Emit": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
+        "resolved": "4.0.1",
+        "contentHash": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
         "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Emit.ILGeneration": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
+        "resolved": "4.0.1",
+        "contentHash": "Ov6dU8Bu15Bc7zuqttgHF12J5lwSWyTf1S+FJouUXVMSqImLZzYaQ+vRr1rQ0OZ0HqsrwWl4dsKHELckQkVpgA==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
+        "resolved": "4.0.1",
+        "contentHash": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Extensions": {
@@ -1384,8 +1369,13 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
+        "resolved": "4.3.0",
+        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
       },
       "System.Threading.Thread": {
         "type": "Transitive",
@@ -1498,15 +1488,15 @@
       "corvus.monitoring.applicationinsights": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Monitoring.Instrumentation.Abstractions": "1.0.0",
-          "Microsoft.ApplicationInsights": "2.9.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.0"
+          "Corvus.Monitoring.Instrumentation.Abstractions": "[1.0.0, )",
+          "Microsoft.ApplicationInsights": "[2.9.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[3.1.*, )"
         }
       },
       "corvus.monitoring.instrumentation.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[3.1.*, )"
         }
       }
     }

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus.Monitoring.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Monitoring.ApplicationInsights
 {
+    using System;
     using System.Collections.Generic;
     using Corvus.Monitoring.Instrumentation;
     using Microsoft.ApplicationInsights;
@@ -28,7 +29,7 @@ namespace Corvus.Monitoring.ApplicationInsights
             this.telemetryClient = telemetryClient;
         }
 
-        /// <inheritdoc />
+                /// <inheritdoc />
         public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail? additionalDetail)
         {
             IOperationHolder<RequestTelemetry> operationHolder = this.telemetryClient.StartOperation<RequestTelemetry>(name);
@@ -60,23 +61,29 @@ namespace Corvus.Monitoring.ApplicationInsights
                 this.operationHolder = operationHolder;
             }
 
-            public void AddOperationDetail(AdditionalInstrumentationDetail detail)
+            public void AddOperationProperty(string name, string value)
             {
-                if (detail.Properties != null)
+                if (string.IsNullOrEmpty(name))
                 {
-                    foreach (KeyValuePair<string, string> property in detail.Properties)
-                    {
-                        this.operationHolder.Telemetry.Properties.Add(property);
-                    }
+                    throw new ArgumentNullException(nameof(name));
                 }
 
-                if (detail.Metrics != null)
+                if (string.IsNullOrEmpty(value))
                 {
-                    foreach (KeyValuePair<string, double> metric in detail.Metrics)
-                    {
-                        this.operationHolder.Telemetry.Metrics.Add(metric);
-                    }
+                    throw new ArgumentNullException(nameof(value));
                 }
+
+                this.operationHolder.Telemetry.Properties.Add(name, value);
+            }
+
+            public void AddOperationMetric(string name, double value)
+            {
+                if (string.IsNullOrEmpty(name))
+                {
+                    throw new ArgumentNullException(nameof(name));
+                }
+
+                this.operationHolder.Telemetry.Metrics.Add(name, value);
             }
 
             public void Dispose()

--- a/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.ApplicationInsights/Corvus/Monitoring/ApplicationInsights/AiOperationsInstrumentation.cs
@@ -29,7 +29,7 @@ namespace Corvus.Monitoring.ApplicationInsights
             this.telemetryClient = telemetryClient;
         }
 
-                /// <inheritdoc />
+        /// <inheritdoc />
         public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail? additionalDetail)
         {
             IOperationHolder<RequestTelemetry> operationHolder = this.telemetryClient.StartOperation<RequestTelemetry>(name);

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
          with bindings in SpecFlow.
          Disabling SA1600, SA1602 (all public types and members to be documented) because test projects need to make lots of types

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Corvus.Monitoring.Instrumentation.Abstractions.Specs.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
          with bindings in SpecFlow.
          Disabling SA1600, SA1602 (all public types and members to be documented) because test projects need to make lots of types

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/OperationDetail.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/Fakes/OperationDetail.cs
@@ -18,14 +18,16 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes
     /// </remarks>
     public class OperationDetail : IOperationInstance
     {
-        private readonly List<AdditionalInstrumentationDetail> furtherDetails = new();
+        private AdditionalInstrumentationDetail furtherDetails = new(
+            new Dictionary<string, string>(),
+            new Dictionary<string, double>());
 
         public OperationDetail(
             string name,
             AdditionalInstrumentationDetail? additionalDetail)
         {
             this.Name = name;
-            this.AdditionalDetail = additionalDetail;
+            this.AdditionalDetail = additionalDetail ?? new();
         }
 
         /// <summary>
@@ -41,9 +43,10 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes
 
         /// <summary>
         /// Gets a list of any further instrumentation detail provided by calls to
-        /// <see cref="IOperationInstance.AddOperationDetail(AdditionalInstrumentationDetail)"/>.
+        /// <see cref="IOperationInstance.AddOperationProperty(string, string)"/> and
+        /// <see cref="IOperationInstance.AddOperationMetric(string, double)"/>.
         /// </summary>
-        public IReadOnlyList<AdditionalInstrumentationDetail> FurtherDetails => this.furtherDetails;
+        public AdditionalInstrumentationDetail FurtherDetails => this.furtherDetails;
 
         /// <summary>
         /// Gets a value indicating whether the code providing instrumentation to our fake has
@@ -52,9 +55,14 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes
         /// </summary>
         public bool IsDisposed { get; private set; }
 
-        void IOperationInstance.AddOperationDetail(AdditionalInstrumentationDetail detail)
+        public void AddOperationMetric(string name, double value)
         {
-            this.furtherDetails.Add(detail);
+            this.furtherDetails.Metrics.Add(name, value);
+        }
+
+        public void AddOperationProperty(string name, string value)
+        {
+            this.furtherDetails.Properties.Add(name, value);
         }
 
         void IDisposable.Dispose()

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingOperationsInstrumentationSpecs.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/SourceTaggingOperationsInstrumentationSpecs.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 {
+    using System.Linq;
     using Corvus.Monitoring.Instrumentation.Abstractions.Specs.Fakes;
     using NUnit.Framework;
 
@@ -148,12 +149,12 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
 
             var furtherDetail1 = new AdditionalInstrumentationDetail
             {
-                Properties = { { ExistingDetailKey, ExistingDetailValue } },
+                Properties = { { "Edk1", "Edv1" } },
                 Metrics = { { "m1", 42.0 } },
             };
             var furtherDetail2 = new AdditionalInstrumentationDetail
             {
-                Properties = { { ExistingDetailKey, ExistingDetailValue } },
+                Properties = { { "Edk2", "Edv2" } },
                 Metrics = { { "m2", 99.0 } },
             };
 
@@ -164,25 +165,15 @@ namespace Corvus.Monitoring.Instrumentation.Abstractions.Specs
             }
 
             OperationDetail opDetail = this.Context.Operations[0];
-            Assert.AreEqual(2, opDetail.FurtherDetails.Count, "FurtherDetails.Count");
-
-            Assert.AreSame(furtherDetail1, opDetail.FurtherDetails[0], "FurtherDetails[0]");
-            Assert.AreSame(furtherDetail2, opDetail.FurtherDetails[1], "FurtherDetails[1]");
 
             // Check they've not changed
-            Assert.AreSame(furtherDetail1.Properties, opDetail.FurtherDetails[0].Properties, "FurtherDetails[0].Properties instance");
-            Assert.AreSame(furtherDetail1.Metrics, opDetail.FurtherDetails[0].Metrics, "FurtherDetails[0].Metrics instance");
-            Assert.AreEqual(1, furtherDetail1.Properties.Count);
-            Assert.AreEqual(ExistingDetailValue, furtherDetail1.Properties[ExistingDetailKey]);
-            Assert.AreEqual(1, furtherDetail1.Metrics.Count);
-            Assert.AreEqual(42.0, furtherDetail1.Metrics["m1"]);
+            Assert.AreEqual(2, opDetail.FurtherDetails.Properties.Count, "FurtherDetails.Properties Count");
+            Assert.AreEqual(2, opDetail.FurtherDetails.Metrics.Count, "FurtherDetails.Metrics Count");
 
-            Assert.AreSame(furtherDetail2.Properties, opDetail.FurtherDetails[1].Properties, "FurtherDetails[1].Properties instance");
-            Assert.AreSame(furtherDetail2.Metrics, opDetail.FurtherDetails[1].Metrics, "FurtherDetails[1].Metrics instance");
-            Assert.AreEqual(1, furtherDetail2.Properties.Count);
-            Assert.AreEqual(ExistingDetailValue, furtherDetail2.Properties[ExistingDetailKey]);
-            Assert.AreEqual(1, furtherDetail2.Metrics.Count);
-            Assert.AreEqual(99.0, furtherDetail2.Metrics["m2"]);
+            Assert.AreEqual("Edv1", opDetail.FurtherDetails.Properties["Edk1"]);
+            Assert.AreEqual("Edv2", opDetail.FurtherDetails.Properties["Edk2"]);
+            Assert.AreEqual(42.0, opDetail.FurtherDetails.Metrics["m1"]);
+            Assert.AreEqual(99.0, opDetail.FurtherDetails.Metrics["m2"]);
         }
 
         private OperationDetail ReportOperation1(AdditionalInstrumentationDetail? suppliedDetail = null)

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/packages.lock.json
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/packages.lock.json
@@ -4,49 +4,49 @@
     ".NETCoreApp,Version=v3.1": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[1.4.7, )",
-        "resolved": "1.4.7",
-        "contentHash": "Vli4LM72bkDNPZQ06bNS6s47o/4UQd0DuussioE4SP/gyx1CIHfctP83imQKivNqeTdpXNIwV5XM/VPtZL6Hxw==",
+        "requested": "[1.6.0, )",
+        "resolved": "1.6.0",
+        "contentHash": "V8v7+oRFK99skWq/TmzgiiS6KYQtu/gJXTXep8HKxt3u1rbU7BZFQfPCHiyH7KSAIn+4HEnxqlvCbXUSyRGCAA==",
         "dependencies": {
-          "Corvus.Testing.SpecFlow": "1.4.7",
+          "Corvus.Testing.SpecFlow": "1.6.0",
           "Microsoft.NET.Test.Sdk": "16.11.0",
-          "Moq": "4.16.1",
-          "SpecFlow.NUnit.Runners": "3.9.40",
-          "coverlet.msbuild": "3.1.0"
+          "Moq": "4.18.2",
+          "SpecFlow.NUnit.Runners": "3.9.74",
+          "coverlet.msbuild": "3.1.2"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "fPzzi16UfB+Ws7Fhwyn95lTt56uZtIvLjvU/QPRQo4XgefOKzxNshlRxlJbMgNLFMAQecDxzoNMJmjGlqU0gwQ==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.0.1",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.22",
-        "contentHash": "QrzfKU8te2X0ykM8XY9YzLvzTGO8qOMq45/Y2sy5gZryQqYe9CxEr0ulwG0idpL+ByK7luX7djmtT8Nv1mMaZw==",
+        "resolved": "3.1.32",
+        "contentHash": "VUbvtpsoHZf4XtBhsfio0+2cpqC9bJs6ZiApT3G81CwBfcDV5OSeU9SaI6it6wxaGf0K2uADzzIS+4yTADaTRg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.22"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.32"
         }
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[3.3.0, )",
-        "resolved": "3.3.0",
-        "contentHash": "yrX3i1javiCEulgi87ZvvV9nEieyv3tOe79Y978TS2Omwj/FX4pLap58U8A1gyPtQEkMcSzsNIoqLOBf+HfuaA=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
-        "requested": "[1.2.0-beta.376, )",
-        "resolved": "1.2.0-beta.376",
-        "contentHash": "uaaVoOYWfIMoWtZsNJwV0m/GI3XAi8BA71e9iBOFDPo3TtAmcGkZ2qcxItkWb6eKI90urOPmxc35BnuhluC1IA==",
+        "requested": "[1.2.0-beta.435, )",
+        "resolved": "1.2.0-beta.435",
+        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
         "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.376"
+          "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
       "BoDi": {
@@ -56,43 +56,34 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "b5rRL5zeaau1y/5hIbI+6mGw3cwun16YjkHZnV9RRT5UyUIFsgLmNXJ0YnIN9p8Hw7K7AbG1q1UclQVU3DinAQ==",
+        "resolved": "5.1.0",
+        "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "System.Collections.Specialized": "4.3.0",
-          "System.ComponentModel": "4.3.0",
-          "System.ComponentModel.TypeConverter": "4.3.0",
-          "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Dynamic.Runtime": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Xml.XmlDocument": "4.3.0"
+          "System.Diagnostics.EventLog": "4.7.0"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.7",
-        "contentHash": "qGqOQt/9x95MOmUyA57JgNmdWRF1lgKjYEjU9IXw3ElMYs5S93I0qHiqBdQCIDq8qHxkXgo6cnDIJsrBLCrReQ==",
+        "resolved": "1.6.0",
+        "contentHash": "0Qg8suJQ6TbvQK1ND51LK6kP0x1lZfqQVpbLf0CqKcIVLrJLmsb2Az+j635D6RJNTZ6jYcWxxtFEh314bERaMQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.21",
-          "Microsoft.Extensions.DependencyInjection": "3.1.21",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.21",
-          "NUnit": "3.13.2",
-          "SpecFlow": "3.9.40",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.31",
+          "Microsoft.Extensions.DependencyInjection": "3.1.31",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.31",
+          "NUnit": "3.13.3",
+          "SpecFlow": "3.9.74",
           "System.Management": "4.7.0"
         }
       },
       "coverlet.msbuild": {
         "type": "Transitive",
-        "resolved": "3.1.0",
-        "contentHash": "xOv5HZagq0I6uF4vt8NVVpwcA2W/uGmNcbLStao2eMk98RQH5NFPQuouh2nWWPSZrNIhGG/iYbBn2pO4s5i+ig=="
+        "resolved": "3.1.2",
+        "contentHash": "QhM0fnDtmIMImY7oxyQ/kh1VYtRxPyRVeLwRUGuUvI6Xp83pSYG9gerK8WgJj4TzUl7ISziADUGtIWKhtlbkbQ=="
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "dVEeGG6a4hTeu8SOgN3ZJaotbtgjuQjOz7xCIOgPZpwzA1JZWZVhk3nGVfs3LjZwkgGbXH3NlHtid621ryN/Pg==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -167,16 +158,16 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.21",
-        "contentHash": "3Ef65E9wCkGJVPQZ7S7GtDJ8JXpCQ3c2b83XLIOINoVV7GSEjKyW/vycc3jQfdc5BIf/lnjodkDiKnjdTzXAZA==",
+        "resolved": "3.1.31",
+        "contentHash": "apqvGW9hYd5khi23FQilW76SRqxzk3E5KraEQFN84imt0KREsGyUIvBG4vedIMORfdDtxgPaHdfl7vPs6nm5oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.21"
+          "Microsoft.Extensions.Primitives": "3.1.31"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "+zBl4NrqANk4JalElpCZ3P2rQ33A3ldRCF1K7RikOuNzEWG5B2M5C+Izas7q5Ub6bFMzAvCJh5E+BtT/gTUD6Q=="
+        "resolved": "3.1.32",
+        "contentHash": "dARl3iAcHZshMvnXtKpLGES4QZq8ExxIQnF2s8pXfP3MJOOXRSBsk+UmA3TMVN4hPr4O2QFS8AMJp9GDD/4lDw=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -192,8 +183,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.21",
-        "contentHash": "hhfhugCsGsceQTSdHhtvOnzgGKUDMxcGIMU8z4m8HTTb99B0Ujf7gyT6C4/0hA/KocSN3p/Flt54Y1db9N2TiA=="
+        "resolved": "3.1.31",
+        "contentHash": "Ta9FclAg2bt7ay40o8ArAMaHKcyojq0eHzPdvZqe1hr28wGLWMSmqxglx1BGgrvY5H9lYiRrReFHovFYx+dsFQ=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",
@@ -267,11 +258,10 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.16.1",
-        "contentHash": "bw3R9q8cVNhWXNpnvWb0OGP4HadS4zvClq+T1zf7AF+tLY1haZ2AvbHidQekf4PDv1T40c6brZeT/V0IBq7cEQ==",
+        "resolved": "4.18.2",
+        "contentHash": "SjxKYS5nX6prcaT8ZjbkONh3vnh0Rxru09+gQ1a07v4TM530Oe/jq3Q4dOZPfo1wq0LYmTgLOZKrqRfEx4auPw==",
         "dependencies": {
-          "Castle.Core": "4.4.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Castle.Core": "5.1.0"
         }
       },
       "NETStandard.Library": {
@@ -318,8 +308,8 @@
       },
       "NUnit": {
         "type": "Transitive",
-        "resolved": "3.13.2",
-        "contentHash": "u+fz/lXyR4vlamySNAEMrXvh+GhAQiB6/aVZtU5WjivR5zF26Ui0tfteDtWqT90k9D8y6g8rFKYQC97Z7d195w==",
+        "resolved": "3.13.3",
+        "contentHash": "KNPDpls6EfHwC3+nnA67fh5wpxeLb3VLFAfLxrug6JMYDLHH6InaQIWR7Sc3y75d/9IKzMksH/gi08W7XWbmnQ==",
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
@@ -483,8 +473,8 @@
       },
       "SpecFlow": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "ru7twstJSKrTv3XfcxyttzrdZ/FvXOF5cYN/x/2js755wVk1zpSPUPa/ml3lSZmPNkS5OAOuSt1JLEa5hhDhdw==",
+        "resolved": "3.9.74",
+        "contentHash": "n6kcg9ZeQWxqJFoT23SsFT89U1QQNwvcN9pAX5alB6ZPr6K0p5D5nGIJ1PZsSaFaRFutiwQ+DicmxBCPAZVYIA==",
         "dependencies": {
           "BoDi": "1.5.0",
           "Gherkin": "19.0.3",
@@ -502,36 +492,36 @@
       },
       "SpecFlow.NUnit": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "+brbJAe0LLzmXh2L78kOJc2fa5EH/7cugmbnfZQdBeWCzL6iFDWFl3MHZ0xx/2BQyu6N/xokqw53Rl30LIo7lw==",
+        "resolved": "3.9.74",
+        "contentHash": "nMPLztTT5IZDMnvNCUxklqaM+agn4kjuNy/qAcYQQOxau2G1MF73UxhL9OXjJQaEuPuyT8gJvXudOYCFZWztxA==",
         "dependencies": {
           "NUnit": "3.13.1",
-          "SpecFlow": "[3.9.40]",
-          "SpecFlow.Tools.MsBuild.Generation": "[3.9.40]"
+          "SpecFlow": "[3.9.74]",
+          "SpecFlow.Tools.MsBuild.Generation": "[3.9.74]"
         }
       },
       "SpecFlow.NUnit.Runners": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "vScntUGHtokExBWweUG9XOkjTum1B14lP4KU9T2rNW+gIGJBG99YmnR3/NMy4YMfASg5VkGJLx4icpZDYJENsQ==",
+        "resolved": "3.9.74",
+        "contentHash": "m595x3GM7CYco+KsXo96irQ2jcjC6+1+41bKdmnTdl3RAvnC4jUZ9f5B5FhGuaVK4+j4GwWi8MZtGMrT//zHLA==",
         "dependencies": {
           "NUnit.Console": "3.12.0",
           "NUnit3TestAdapter": "3.17.0",
-          "SpecFlow.NUnit": "[3.9.40]"
+          "SpecFlow.NUnit": "[3.9.74]"
         }
       },
       "SpecFlow.Tools.MsBuild.Generation": {
         "type": "Transitive",
-        "resolved": "3.9.40",
-        "contentHash": "DFClKzQH0ijUBiZNpas8sQ66EdGwVSS18UtC1hVIM7PiT0F+xzKs4VX5hsz+ZY/RKyQEfY9HELUAC8AoZicxSg==",
+        "resolved": "3.9.74",
+        "contentHash": "I/9OvmKOohJqIUNJ0xGYJCWfL6WKDaes8OoOAD/2yhGX+tzC5ofs9yqkP9Cu/xfnIx+11IR3pZs7YhBhGAcgWQ==",
         "dependencies": {
-          "SpecFlow": "[3.9.40]"
+          "SpecFlow": "[3.9.74]"
         }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
-        "resolved": "1.2.0.376",
-        "contentHash": "a009jDRd7zP6h+jenZ7nGjqkkFkEuxmT9FeM334cLDwodfU2x/nNcsFqw2Pjd4wVPiyX+qjLq+vhhbE3OPzFMw=="
+        "resolved": "1.2.0.435",
+        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -682,6 +672,16 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "iDoKGQcRwX0qwY+eAEkaJGae0d/lHlxtslO+t8pJWAUxlvY3tqLtVOPnW2UU4cFjP0Y/L1QBqhkZfSyGqVMR2w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.Registry": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
       "System.Diagnostics.Process": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -720,22 +720,6 @@
           "System.Runtime": "4.1.0"
         }
       },
-      "System.Diagnostics.TraceSource": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "runtime.native.System": "4.3.0"
-        }
-      },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -748,23 +732,24 @@
       },
       "System.Dynamic.Runtime": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
+        "resolved": "4.0.11",
+        "contentHash": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Globalization": {
@@ -850,26 +835,26 @@
       },
       "System.Linq.Expressions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
+        "resolved": "4.1.0",
+        "contentHash": "I+y02iqkgmCAyfbqOmSDOgqdZQ5tTj80Akm5BPSS8EeB0VGWdy6X1KCoYe8Pk6pwDoAKZUOdLVxnTJcExiv5zw==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Management": {
@@ -928,14 +913,14 @@
       },
       "System.ObjectModel": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
+        "resolved": "4.0.12",
+        "contentHash": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Reflection": {
@@ -952,35 +937,35 @@
       },
       "System.Reflection.Emit": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
+        "resolved": "4.0.1",
+        "contentHash": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
         "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Emit.ILGeneration": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
+        "resolved": "4.0.1",
+        "contentHash": "Ov6dU8Bu15Bc7zuqttgHF12J5lwSWyTf1S+FJouUXVMSqImLZzYaQ+vRr1rQ0OZ0HqsrwWl4dsKHELckQkVpgA==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
+        "resolved": "4.0.1",
+        "contentHash": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Reflection.Extensions": {
@@ -1337,8 +1322,13 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
+        "resolved": "4.3.0",
+        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
       },
       "System.Threading.Thread": {
         "type": "Transitive",
@@ -1451,7 +1441,7 @@
       "corvus.monitoring.instrumentation.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[3.1.*, )"
         }
       }
     }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/packages.lock.json
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions.Specs/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    "net6.0": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
         "requested": "[1.6.0, )",
@@ -59,7 +59,7 @@
         "resolved": "5.1.0",
         "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
         "dependencies": {
-          "System.Diagnostics.EventLog": "4.7.0"
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "Corvus.Testing.SpecFlow": {
@@ -674,13 +674,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "iDoKGQcRwX0qwY+eAEkaJGae0d/lHlxtslO+t8pJWAUxlvY3tqLtVOPnW2UU4cFjP0Y/L1QBqhkZfSyGqVMR2w==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "3.1.0",
-          "Microsoft.Win32.Registry": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Diagnostics.Process": {
         "type": "Transitive",

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus.Monitoring.Instrumentation.Abstractions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
@@ -5,6 +5,7 @@
 namespace Corvus.Monitoring.Instrumentation
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A logical operation in progress.
@@ -42,5 +43,28 @@ namespace Corvus.Monitoring.Instrumentation
         /// <param name="name">The metric name.</param>
         /// <param name="value">The metric value.</param>
         void AddOperationMetric(string name, double value);
+
+        /// <summary>
+        /// Adds one or more entries to the additional data associated with this request.
+        /// </summary>
+        /// <param name="detail">The detail to add.</param>
+        void AddOperationDetail(AdditionalInstrumentationDetail detail)
+        {
+            if (detail.Properties != null)
+            {
+                foreach (KeyValuePair<string, string> property in detail.Properties)
+                {
+                    this.AddOperationProperty(property.Key, property.Value);
+                }
+            }
+
+            if (detail.Metrics != null)
+            {
+                foreach (KeyValuePair<string, double> metric in detail.Metrics)
+                {
+                    this.AddOperationMetric(metric.Key, metric.Value);
+                }
+            }
+        }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/IOperationInstance.cs
@@ -30,9 +30,17 @@ namespace Corvus.Monitoring.Instrumentation
     public interface IOperationInstance : IDisposable
     {
         /// <summary>
-        /// Adds one or more entries to the additional data associated with this request.
+        /// Adds a property to the additional data associated with this request.
         /// </summary>
-        /// <param name="detail">The detail to add.</param>
-        void AddOperationDetail(AdditionalInstrumentationDetail detail);
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        void AddOperationProperty(string name, string value);
+
+        /// <summary>
+        /// Adds a metric value to the additional data associated with this request.
+        /// </summary>
+        /// <param name="name">The metric name.</param>
+        /// <param name="value">The metric value.</param>
+        void AddOperationMetric(string name, double value);
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
@@ -26,8 +26,14 @@ namespace Corvus.Monitoring.Instrumentation
         {
             public static readonly Operation Instance = new();
 
-            public void AddOperationDetail(AdditionalInstrumentationDetail detail)
+            public void AddOperationMetric(string name, double value)
             {
+                throw new System.NotImplementedException();
+            }
+
+            public void AddOperationProperty(string name, string value)
+            {
+                throw new System.NotImplementedException();
             }
 
             public void Dispose()

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/NullOperationsInstrumentation.cs
@@ -28,12 +28,10 @@ namespace Corvus.Monitoring.Instrumentation
 
             public void AddOperationMetric(string name, double value)
             {
-                throw new System.NotImplementedException();
             }
 
             public void AddOperationProperty(string name, string value)
             {
-                throw new System.NotImplementedException();
             }
 
             public void Dispose()

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="OperationInstanceExtensions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Monitoring.Instrumentation
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extension methods for <see cref="IOperationInstance"/>s.
+    /// </summary>
+    public static class OperationInstanceExtensions
+    {
+        /// <summary>
+        /// Adds a property to the additional data associated with this request.
+        /// </summary>
+        /// <param name="operation">The operation to add detail to.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        public static void AddOperationProperty(this IOperationInstance operation, string name, object value)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            operation.AddOperationProperty(name, value.ToString());
+        }
+
+        /// <summary>
+        /// Adds one or more entries to the additional data associated with this request.
+        /// </summary>
+        /// <param name="operation">The operation to add detail to.</param>
+        /// <param name="detail">The detail to add.</param>
+        public static void AddOperationDetail(this IOperationInstance operation, AdditionalInstrumentationDetail detail)
+        {
+            if (detail.Properties != null)
+            {
+                foreach (KeyValuePair<string, string> property in detail.Properties)
+                {
+                    operation.AddOperationProperty(property.Key, property.Value);
+                }
+            }
+
+            if (detail.Metrics != null)
+            {
+                foreach (KeyValuePair<string, double> metric in detail.Metrics)
+                {
+                    operation.AddOperationMetric(metric.Key, metric.Value);
+                }
+            }
+        }
+    }
+}

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
@@ -25,7 +25,7 @@ namespace Corvus.Monitoring.Instrumentation
                 throw new ArgumentNullException(nameof(value));
             }
 
-            operation.AddOperationProperty(name, value.ToString());
+            operation.AddOperationProperty(name, value.ToString()!);
         }
 
         /// <summary>

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/OperationInstanceExtensions.cs
@@ -5,7 +5,6 @@
 namespace Corvus.Monitoring.Instrumentation
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Extension methods for <see cref="IOperationInstance"/>s.
@@ -26,30 +25,6 @@ namespace Corvus.Monitoring.Instrumentation
             }
 
             operation.AddOperationProperty(name, value.ToString()!);
-        }
-
-        /// <summary>
-        /// Adds one or more entries to the additional data associated with this request.
-        /// </summary>
-        /// <param name="operation">The operation to add detail to.</param>
-        /// <param name="detail">The detail to add.</param>
-        public static void AddOperationDetail(this IOperationInstance operation, AdditionalInstrumentationDetail detail)
-        {
-            if (detail.Properties != null)
-            {
-                foreach (KeyValuePair<string, string> property in detail.Properties)
-                {
-                    operation.AddOperationProperty(property.Key, property.Value);
-                }
-            }
-
-            if (detail.Metrics != null)
-            {
-                foreach (KeyValuePair<string, double> metric in detail.Metrics)
-                {
-                    operation.AddOperationMetric(metric.Key, metric.Value);
-                }
-            }
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/TaggingPropertySource.cs
+++ b/Solutions/Corvus.Monitoring.Instrumentation.Abstractions/Corvus/Monitoring/Instrumentation/TaggingPropertySource.cs
@@ -75,12 +75,12 @@ namespace Corvus.Monitoring.Instrumentation
         {
             if (t.IsGenericType)
             {
-                string nameWithArity = t.GetGenericTypeDefinition().FullName;
+                string nameWithArity = t.GetGenericTypeDefinition().FullName!;
                 int arityMarkerIndex = nameWithArity.LastIndexOf('`');
                 return nameWithArity.Substring(0, arityMarkerIndex);
             }
 
-            return t.FullName;
+            return t.FullName!;
         }
     }
 }

--- a/Solutions/Corvus.Monitoring.lutconfig
+++ b/Solutions/Corvus.Monitoring.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository>..\</Repository>
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>


### PR DESCRIPTION
The original definition of `IOperationInstance` expected any additional properties or metrics that are added to the operation to be supplied in bulk, in the form of an `AdditionalInstrumentationDetail` instance.

There are scenarios where it's useful to incrementally add to the properties/metrics for an in-flight operation. As such, the interface has been modified to provide individual methods to add a property or metric to the operation. The existing method for bulk addition of data has been pulled out into an extension method that uses the new methods.

This is technically a breaking change, so the next version should be 2.0. However, for any code that doesn't provide an implementation of `IOperationInstance`, existing code should recompile without changes.

Since this is a breaking change already, this PR also includes the planned update from netstandard2.0 to net6.